### PR TITLE
make sure current password is entered when changing passwords

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -58,7 +58,7 @@ async function changePassword(req, res) {
     const user = await User.findById(req.user._id);
     if (!user) throw new Error("User not found");
 
-    const isMatch = user.comparePassword(req.body.password);
+    const isMatch = await user.comparePassword(req.body.password);
     if (!isMatch) throw new Error("Incorrect password");
 
     user.password = req.body.newPassword;


### PR DESCRIPTION
Tiny change. Added `await` here so that we get the actual true/false value. Otherwise it will allow user to change password even if they enter the wrong current password.